### PR TITLE
Remove needless and potentially harmful #ifdef _cplusplus extern "C"

### DIFF
--- a/Base64.xs
+++ b/Base64.xs
@@ -25,16 +25,10 @@ metamail, which comes with this message:
 */
 
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #define PERL_NO_GET_CONTEXT     /* we want efficiency */
 #include "EXTERN.h"
 #include "perl.h"
 #include "XSUB.h"
-#ifdef __cplusplus
-}
-#endif
 
 #define MAX_LINE  76 /* size of encoded lines */
 


### PR DESCRIPTION
When building core perl, and hence MIME-Base64, in C++ mode on Windows
the #include of perl's headers within an extern "C" { ... } forces
unmangled symbol names to be referenced in the perlXXX.dll, but due to
a current bug in the C++ mode build of perl a few symbols actually
appear with mangled names, causing a linker failure in MIME-Base64.

The C++ mode build on Windows is currently a work in progress and
hopefully the mangled names bug will be fixed in due course, but I do
not see any benefit in MIME-Base64 #including the headers in extern "C"
anyway. In a C mode build the extern "C" thing isn't done due to the
#ifdef; in a C++ mode build it works if perl is correctly built with
unmangled names but otherwise just causes breakage when things would
have worked fine without it (since without it, MIME-Base64 will simply
reference the same (currently mangled) symbol name that perl is
exporting).

There are a few other XS modules in the core which have a similar
extern "C" thing around the #includes, but the vast majority do not.
Unless you know of a specific reason for having it then I think it
would be better off without it. It has been present in MIME-Base64
ever since the first revision of Base64.xs:
https://github.com/gisle/mime-base64/commit/efffe2b6c8

There is a thread on perl5-porters regarding this. See the end of
this message in particular:
http://www.nntp.perl.org/group/perl.perl5.porters/2015/01/msg224999.html